### PR TITLE
Add support for viewing trunk port information

### DIFF
--- a/esiclient/tests/test_utils.py
+++ b/esiclient/tests/test_utils.py
@@ -1,0 +1,159 @@
+#   Licensed under the Apache License, Version 2.0 (the "License"); you may
+#   not use this file except in compliance with the License. You may obtain
+#   a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#   License for the specific language governing permissions and limitations
+#   under the License.
+#
+
+import mock
+from unittest import TestCase
+
+from esiclient.tests import utils as test_utils
+from esiclient import utils
+
+
+class TestGetNetworkDisplayName(TestCase):
+
+    def test_get_network_display_name(self):
+        network = test_utils.create_mock_object({
+            "id": "network_uuid",
+            "name": "test_network",
+            "provider_segmentation_id": "777"
+        })
+
+        results = utils.get_network_display_name(network)
+        self.assertEqual('test_network (777)', results)
+
+    def test_get_network_display_name_no_segmentation_id(self):
+        network = test_utils.create_mock_object({
+            "id": "network_uuid",
+            "name": "test_network"
+        })
+
+        results = utils.get_network_display_name(network)
+        self.assertEqual('test_network', results)
+
+
+class TestGetNetworkInfoFromPort(TestCase):
+
+    def setUp(self):
+        super(TestGetNetworkInfoFromPort, self).setUp()
+        self.network = test_utils.create_mock_object({
+            "id": "network_uuid",
+            "name": "test_network",
+            "provider_segmentation_id": "777"
+        })
+
+        self.neutron_client = mock.Mock()
+        self.neutron_client.get_network.return_value = self.network
+
+    def test_get_network_info_from_port(self):
+        port = test_utils.create_mock_object({
+            "id": "port_uuid",
+            "name": "test_port",
+            "network_id": "network_uuid",
+            "fixed_ips": [{"ip_address": '11.22.33.44'}]
+        })
+
+        results = utils.get_network_info_from_port(port, self.neutron_client)
+        self.assertEqual(('test_network (777)', '11.22.33.44'), results)
+
+    def test_get_network_info_from_port_no_fixed_ips(self):
+        port = test_utils.create_mock_object({
+            "id": "port_uuid",
+            "name": "test_port",
+            "network_id": "network_uuid",
+            "fixed_ips": None
+        })
+
+        results = utils.get_network_info_from_port(port, self.neutron_client)
+        self.assertEqual(('test_network (777)', ''), results)
+
+
+class TestGetFullNetworkInfoFromPort(TestCase):
+
+    def setUp(self):
+        super(TestGetFullNetworkInfoFromPort, self).setUp()
+        self.network1 = test_utils.create_mock_object({
+            "id": "network_uuid_1",
+            "name": "test_network",
+            "provider_segmentation_id": "777"
+        })
+        self.network2 = test_utils.create_mock_object({
+            "id": "network_uuid_2",
+            "name": "test_network_2",
+            "provider_segmentation_id": "888"
+        })
+        self.subport1 = test_utils.create_mock_object({
+            "id": "subport_uuid_1",
+            "name": "test_subport_1",
+            "network_id": "network_uuid_1",
+            "fixed_ips": [{"ip_address": '11.22.33.44'}]
+        })
+        self.subport2 = test_utils.create_mock_object({
+            "id": "subport_uuid_2",
+            "name": "test_subport_2",
+            "network_id": "network_uuid_2",
+            "fixed_ips": [{"ip_address": '55.66.77.88'}]
+        })
+
+        self.neutron_client = mock.Mock()
+
+        def mock_network_get(network_uuid):
+            if network_uuid == "network_uuid_1":
+                return self.network1
+            elif network_uuid == "network_uuid_2":
+                return self.network2
+            return None
+        self.neutron_client.get_network.side_effect = mock_network_get
+
+        def mock_port_get(port_uuid):
+            if port_uuid == "subport_uuid_1":
+                return self.subport1
+            elif port_uuid == "subport_uuid_2":
+                return self.subport2
+            return None
+        self.neutron_client.get_port.side_effect = mock_port_get
+
+    def test_get_full_network_info_from_port(self):
+        port = test_utils.create_mock_object({
+            "id": "port_uuid",
+            "name": "test_port",
+            "network_id": "network_uuid_1",
+            "fixed_ips": [{"ip_address": '77.77.77.77'}],
+            "trunk_details": {
+                "trunk_id": "trunk_uuid",
+                "sub_ports": [
+                    {"segmentation_id": "777", "port_id": "subport_uuid_1"},
+                    {"segmentation_id": "888", "port_id": "subport_uuid_2"},
+                ]
+            }
+        })
+
+        results = utils.get_full_network_info_from_port(port,
+                                                        self.neutron_client)
+        self.assertEqual((
+            ['test_network (777)',
+             'test_network (777)',
+             'test_network_2 (888)'],
+            ['77.77.77.77', '11.22.33.44', '55.66.77.88']
+        ), results)
+
+    def test_get_full_network_info_from_port_no_trunk(self):
+        port = test_utils.create_mock_object({
+            "id": "port_uuid",
+            "name": "test_port",
+            "network_id": "network_uuid_1",
+            "fixed_ips": [{"ip_address": '77.77.77.77'}],
+            "trunk_details": None
+        })
+
+        results = utils.get_full_network_info_from_port(port,
+                                                        self.neutron_client)
+        self.assertEqual((['test_network (777)'], ['77.77.77.77']), results)

--- a/esiclient/tests/utils.py
+++ b/esiclient/tests/utils.py
@@ -15,7 +15,7 @@ import mock
 
 
 def create_mock_object(mock_attributes):
-    mock_object = mock.Mock()
+    mock_object = mock.Mock(spec=[])
     mock_object.configure_mock(**mock_attributes)
 
     return mock_object

--- a/esiclient/utils.py
+++ b/esiclient/utils.py
@@ -1,0 +1,65 @@
+#   Licensed under the Apache License, Version 2.0 (the "License"); you may
+#   not use this file except in compliance with the License. You may obtain
+#   a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#   License for the specific language governing permissions and limitations
+#   under the License.
+
+
+def get_network_display_name(network):
+    """Return Neutron network name with vlan, if any
+
+    :param network: a Neutron network
+    """
+    try:
+        return "{0} ({1})".format(
+            network.name, network.provider_segmentation_id)
+    except Exception:
+        # if user does not have permission to see provider_segmentation_id,
+        # just show the name
+        return network.name
+
+
+def get_network_info_from_port(port, client):
+    """Return Neutron network name and ips from port
+
+    :param port: a Neutron port
+    :param client: neutron client
+    """
+    network = client.get_network(port.network_id)
+    fixed_ip = ''
+    if port.fixed_ips and len(port.fixed_ips) > 0:
+        fixed_ip = port.fixed_ips[0]['ip_address']
+
+    return get_network_display_name(network), fixed_ip
+
+
+def get_full_network_info_from_port(port, client):
+    """Return full Neutron network name and ips from port
+
+    This code iterates through subports if appropriate
+
+    :param port: a Neutron port
+    :param client: neutron client
+    """
+    names = []
+    fixed_ips = []
+
+    name, fixed_ip = get_network_info_from_port(port, client)
+    names.append(name)
+    fixed_ips.append(fixed_ip)
+
+    if port.trunk_details:
+        subports = port.trunk_details['sub_ports']
+        for subport_info in subports:
+            subport = client.get_port(subport_info['port_id'])
+            name, fixed_ip = get_network_info_from_port(subport, client)
+            names.append(name)
+            fixed_ips.append(fixed_ip)
+
+    return names, fixed_ips


### PR DESCRIPTION
This update checks ports for trunk information where appropriate,
and iterates through subports to display relevant information.