### PR TITLE
Add CLI commands for managing trunk ports

### DIFF
--- a/esiclient/tests/test_utils.py
+++ b/esiclient/tests/test_utils.py
@@ -139,9 +139,9 @@ class TestGetFullNetworkInfoFromPort(TestCase):
         results = utils.get_full_network_info_from_port(port,
                                                         self.neutron_client)
         self.assertEqual((
-            ['test_network (777)',
-             'test_network (777)',
+            ['test_network (777)', 'test_network (777)',
              'test_network_2 (888)'],
+            ['test_port', 'test_subport_1', 'test_subport_2'],
             ['77.77.77.77', '11.22.33.44', '55.66.77.88']
         ), results)
 
@@ -156,4 +156,7 @@ class TestGetFullNetworkInfoFromPort(TestCase):
 
         results = utils.get_full_network_info_from_port(port,
                                                         self.neutron_client)
-        self.assertEqual((['test_network (777)'], ['77.77.77.77']), results)
+        self.assertEqual(
+            (['test_network (777)'], ['test_port'], ['77.77.77.77']),
+            results
+        )

--- a/esiclient/tests/v1/test_node_network.py
+++ b/esiclient/tests/v1/test_node_network.py
@@ -116,7 +116,8 @@ class TestList(base.TestCommand):
             assert_called_once_with(detail=True)
 
     @mock.patch('esiclient.utils.get_full_network_info_from_port',
-                return_value=(["test_network"], ["2.2.2.2"]),
+                return_value=(["test_network"], ["node2"],
+                              ["2.2.2.2"]),
                 autospec=True)
     def test_take_action_node_filter(self, mock_gfnifp):
         self.app.client_manager.baremetal.port.list.\
@@ -144,9 +145,9 @@ class TestList(base.TestCommand):
     def test_take_action_network_filter(self, mock_gfnifp):
         def mock_gfnifp_values(port, client):
             if port.id == 'neutron_port_uuid_1':
-                return ['test_network'], ['1.1.1.1']
+                return ['test_network'], ['node1'], ['1.1.1.1']
             elif port.id == 'neutron_port_uuid_2':
-                return ['test_network'], ['2.2.2.2']
+                return ['test_network'], ['node2'], ['2.2.2.2']
             return None
         mock_gfnifp.side_effect = mock_gfnifp_values
 
@@ -172,7 +173,8 @@ class TestList(base.TestCommand):
         self.assertEqual(mock_gfnifp.call_count, 2)
 
     @mock.patch('esiclient.utils.get_full_network_info_from_port',
-                return_value=(["test_network"], ["2.2.2.2"]),
+                return_value=(["test_network"], ["node2"],
+                              ["2.2.2.2"]),
                 autospec=True)
     def test_take_action_node_network_filter(self, mock_gfnifp):
         self.app.client_manager.baremetal.port.list.\
@@ -263,7 +265,8 @@ class TestAttach(base.TestCommand):
             return_value = self.neutron_port
 
     @mock.patch('esiclient.utils.get_full_network_info_from_port',
-                return_value=(["test_network"], ["2.2.2.2"]),
+                return_value=(["test_network"], ["node2"],
+                              ["2.2.2.2"]),
                 autospec=True)
     def test_take_action_network(self, mock_gfnifp):
         self.app.client_manager.baremetal.node.get.\
@@ -291,7 +294,8 @@ class TestAttach(base.TestCommand):
         mock_gfnifp.assert_called_once
 
     @mock.patch('esiclient.utils.get_full_network_info_from_port',
-                return_value=(["test_network"], ["2.2.2.2"]),
+                return_value=(["test_network"], ["node2"],
+                              ["2.2.2.2"]),
                 autospec=True)
     def test_take_action_port(self, mock_gfnifp):
         self.app.client_manager.baremetal.node.get.\
@@ -320,7 +324,8 @@ class TestAttach(base.TestCommand):
         mock_gfnifp.assert_called_once
 
     @mock.patch('esiclient.utils.get_full_network_info_from_port',
-                return_value=(["test_network"], ["2.2.2.2"]),
+                return_value=(["test_network"], ["node2"],
+                              ["2.2.2.2"]),
                 autospec=True)
     def test_take_action_port_and_mac_address(self, mock_gfnifp):
         self.app.client_manager.baremetal.node.get.\
@@ -375,7 +380,8 @@ class TestAttach(base.TestCommand):
             self.cmd.take_action, parsed_args)
 
     @mock.patch('esiclient.utils.get_full_network_info_from_port',
-                return_value=(["test_network"], ["2.2.2.2"]),
+                return_value=(["test_network"], ["node2"],
+                              ["2.2.2.2"]),
                 autospec=True)
     def test_take_action_adopt(self, mock_gfnifp):
         self.app.client_manager.baremetal.node.get.\
@@ -415,7 +421,8 @@ class TestAttach(base.TestCommand):
         mock_gfnifp.assert_called_once
 
     @mock.patch('esiclient.utils.get_full_network_info_from_port',
-                return_value=(["test_network"], ["2.2.2.2"]),
+                return_value=(["test_network"], ["node2"],
+                              ["2.2.2.2"]),
                 autospec=True)
     def test_take_action_adopt_no_update(self, mock_gfnifp):
         self.app.client_manager.baremetal.node.get.\

--- a/esiclient/tests/v1/test_trunk.py
+++ b/esiclient/tests/v1/test_trunk.py
@@ -1,0 +1,330 @@
+#   Licensed under the Apache License, Version 2.0 (the "License"); you may
+#   not use this file except in compliance with the License. You may obtain
+#   a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#   License for the specific language governing permissions and limitations
+#   under the License.
+#
+
+import mock
+
+from esiclient.tests import base
+from esiclient.tests import utils
+from esiclient.v1 import trunk
+
+
+class TestList(base.TestCommand):
+
+    def setUp(self):
+        super(TestList, self).setUp()
+        self.cmd = trunk.List(self.app, None)
+
+        self.port1 = utils.create_mock_object({
+            "id": "port_uuid_1",
+            "network_id": "network_uuid_1",
+            "name": "trunk1-network1-trunk-port",
+            "mac_address": "aa:aa:aa:aa:aa:aa",
+        })
+        self.subport1 = utils.create_mock_object({
+            "id": "port_uuid_2",
+            "network_id": "network_uuid_2",
+            "name": "trunk1-network2-sub-port",
+            "mac_address": "bb:bb:bb:bb:bb:bb",
+        })
+        self.subport2 = utils.create_mock_object({
+            "id": "port_uuid_3",
+            "network_id": "network_uuid_3",
+            "name": "trunk1-network3-sub-port",
+            "mac_address": "cc:cc:cc:cc:cc:cc",
+        })
+        self.port2 = utils.create_mock_object({
+            "id": "port_uuid_4",
+            "network_id": "network_uuid_4",
+            "name": "trunk2-network4-trunk-port",
+            "mac_address": "dd:dd:dd:dd:dd:dd",
+        })
+        self.subport3 = utils.create_mock_object({
+            "id": "port_uuid_5",
+            "network_id": "network_uuid_5",
+            "name": "trunk2-network5-sub-port",
+            "mac_address": "ee:ee:ee:ee:ee",
+        })
+        self.trunk1 = utils.create_mock_object({
+            "id": "trunk_uuid_1",
+            "name": "trunk1",
+            "port_id": "port_uuid_1",
+            "sub_ports": [
+                {
+                    "port_id": 'port_uuid_2',
+                    "segmentation_id": '222',
+                    "segmentation_type": 'vlan'
+                },
+                {
+                    "port_id": 'port_uuid_3',
+                    "segmentation_id": '333',
+                    "segmentation_type": 'vlan'
+                }
+            ]
+        })
+        self.trunk2 = utils.create_mock_object({
+            "id": "trunk_uuid_2",
+            "name": "trunk2",
+            "port_id": "port_uuid_4",
+            "sub_ports": [
+                {
+                    "port_id": 'port_uuid_5',
+                    "segmentation_id": '555',
+                    "segmentation_type": 'vlan'
+                }
+            ]
+        })
+
+        self.app.client_manager.network.trunks.\
+            return_value = [self.trunk1, self.trunk2]
+
+        def mock_get_port(port_id):
+            if port_id == "port_uuid_1":
+                return self.port1
+            if port_id == "port_uuid_4":
+                return self.port2
+            return None
+        self.app.client_manager.network.get_port.\
+            side_effect = mock_get_port
+
+    @mock.patch('esiclient.utils.get_full_network_info_from_port',
+                autospec=True)
+    def test_take_action(self, mock_gfnifp):
+        def mock_get_fnifp(port, client):
+            if port.id == "port_uuid_1":
+                return (["network1", "network2", "network3"],
+                        ["trunk1-network1-trunk-port",
+                         "trunk1-network2-sub-port",
+                         "trunk1-network3-sub-port"],
+                        ["1.1.1.1", "2.2.2.2", "3.3.3.3"])
+            if port.id == "port_uuid_4":
+                return (["network4", "network5"],
+                        ["trunk2-network4-trunk-port",
+                         "trunk2-network5-sub-port"],
+                        ["4.4.4.4", "5.5.5.5"])
+            return None
+        mock_gfnifp.side_effect = mock_get_fnifp
+
+        arglist = []
+        verifylist = []
+
+        parsed_args = self.check_parser(self.cmd, arglist, verifylist)
+
+        results = self.cmd.take_action(parsed_args)
+        expected = (
+            ['Trunk', 'Port', 'Network'],
+            [
+                ['trunk1',
+                 'trunk1-network1-trunk-port\n'
+                 'trunk1-network2-sub-port\n'
+                 'trunk1-network3-sub-port',
+                 'network1\nnetwork2\nnetwork3'],
+                ['trunk2',
+                 'trunk2-network4-trunk-port\ntrunk2-network5-sub-port',
+                 'network4\nnetwork5']
+            ]
+        )
+
+        self.assertEqual(expected, results)
+        self.app.client_manager.network.get_port.\
+            assert_has_calls([
+                mock.call("port_uuid_1"),
+                mock.call("port_uuid_4")
+            ])
+        mock_gfnifp.assert_has_calls([
+                mock.call(self.port1, self.app.client_manager.network),
+                mock.call(self.port2, self.app.client_manager.network)
+            ])
+
+
+class TestCreate(base.TestCommand):
+
+    def setUp(self):
+        super(TestCreate, self).setUp()
+        self.cmd = trunk.Create(self.app, None)
+
+        self.network1 = utils.create_mock_object({
+            "id": "network_uuid_1",
+            "name": "network1",
+            "provider_segmentation_id": 111
+        })
+        self.network2 = utils.create_mock_object({
+            "id": "network_uuid_2",
+            "name": "network2",
+            "provider_segmentation_id": 222
+        })
+        self.network3 = utils.create_mock_object({
+            "id": "network_uuid_3",
+            "name": "network3",
+            "provider_segmentation_id": 333
+        })
+        self.port = utils.create_mock_object({
+            "id": "port_uuid_1",
+            "network_id": "network_uuid_1",
+            "name": "trunk-network1-trunk-port",
+            "mac_address": "aa:aa:aa:aa:aa:aa",
+        })
+        self.subport1 = utils.create_mock_object({
+            "id": "port_uuid_2",
+            "network_id": "network_uuid_2",
+            "name": "trunk-network2-sub-port",
+            "mac_address": "bb:bb:bb:bb:bb:bb",
+        })
+        self.subport2 = utils.create_mock_object({
+            "id": "port_uuid_3",
+            "network_id": "network_uuid_3",
+            "name": "trunk-network3-sub-port",
+            "mac_address": "cc:cc:cc:cc:cc:cc",
+        })
+        self.trunk = utils.create_mock_object({
+            "id": "trunk_uuid",
+            "name": "trunk",
+            "port_id": "port_uuid_1",
+            "sub_ports": [
+                {
+                    "port_id": 'port_uuid_2',
+                    "segmentation_id": '222',
+                    "segmentation_type": 'vlan'
+                },
+                {
+                    "port_id": 'port_uuid_3',
+                    "segmentation_id": '333',
+                    "segmentation_type": 'vlan'
+                }
+            ]
+        })
+
+        def mock_find_network(network_name):
+            if network_name == "network1":
+                return self.network1
+            if network_name == "network2":
+                return self.network2
+            if network_name == "network3":
+                return self.network3
+            return None
+        self.app.client_manager.network.find_network.\
+            side_effect = mock_find_network
+
+        def mock_create_port(name, network_id):
+            if network_id == "network_uuid_1":
+                return self.port
+            if network_id == "network_uuid_2":
+                return self.subport1
+            if network_id == "network_uuid_3":
+                return self.subport2
+            return None
+        self.app.client_manager.network.create_port.\
+            side_effect = mock_create_port
+
+        self.app.client_manager.network.create_trunk.\
+            return_value = self.trunk
+
+    def test_take_action(self):
+        arglist = ['trunk', '--native-network', 'network1',
+                   '--tagged-networks', 'network2',
+                   '--tagged-networks', 'network3']
+        verifylist = []
+
+        parsed_args = self.check_parser(self.cmd, arglist, verifylist)
+
+        results = self.cmd.take_action(parsed_args)
+        expected = (
+            ['Trunk', 'Port', 'Sub Ports'],
+            ['trunk', 'trunk-network1-trunk-port',
+             [{'port_id': 'port_uuid_2',
+               'segmentation_id': '222',
+               'segmentation_type': 'vlan'},
+              {'port_id': 'port_uuid_3',
+               'segmentation_id': '333',
+               'segmentation_type': 'vlan'}]]
+        )
+
+        self.assertEqual(expected, results)
+        self.app.client_manager.network.create_port.\
+            assert_has_calls([
+                mock.call(name="trunk-network1-trunk-port",
+                          network_id="network_uuid_1"),
+                mock.call(name="trunk-network2-sub-port",
+                          network_id="network_uuid_2"),
+                mock.call(name="trunk-network3-sub-port",
+                          network_id="network_uuid_3")
+            ])
+        self.app.client_manager.network.find_network.\
+            assert_has_calls([
+                mock.call("network1"),
+                mock.call("network2"),
+                mock.call("network3")
+            ])
+        self.app.client_manager.network.create_trunk.\
+            assert_called_once_with(
+                name="trunk",
+                port_id="port_uuid_1",
+                sub_ports=[
+                    {'port_id': 'port_uuid_2',
+                     'segmentation_type': 'vlan',
+                     'segmentation_id': 222},
+                    {'port_id': 'port_uuid_3',
+                     'segmentation_type': 'vlan',
+                     'segmentation_id': 333}
+                ]
+            )
+
+
+class TestDelete(base.TestCommand):
+
+    def setUp(self):
+        super(TestDelete, self).setUp()
+        self.cmd = trunk.Delete(self.app, None)
+
+        self.trunk = utils.create_mock_object({
+            "id": "trunk_uuid",
+            "name": "trunk",
+            "port_id": "port_uuid_1",
+            "sub_ports": [
+                {
+                    "port_id": 'port_uuid_2',
+                    "segmentation_id": '222',
+                    "segmentation_type": 'vlan'
+                },
+                {
+                    "port_id": 'port_uuid_3',
+                    "segmentation_id": '333',
+                    "segmentation_type": 'vlan'
+                }
+            ]
+        })
+
+        self.app.client_manager.network.find_trunk.\
+            return_value = self.trunk
+        self.app.client_manager.network.delete_trunk.\
+            return_value = None
+        self.app.client_manager.network.delete_port.\
+            return_value = None
+
+    def test_take_action(self):
+        arglist = ['trunk']
+        verifylist = []
+
+        parsed_args = self.check_parser(self.cmd, arglist, verifylist)
+
+        self.cmd.take_action(parsed_args)
+
+        self.app.client_manager.network.find_trunk.\
+            assert_called_once_with("trunk")
+        self.app.client_manager.network.delete_trunk.\
+            assert_called_once_with("trunk_uuid")
+        self.app.client_manager.network.delete_port.\
+            assert_has_calls([
+                mock.call("port_uuid_2"),
+                mock.call("port_uuid_3"),
+                mock.call("port_uuid_1"),
+            ])

--- a/esiclient/utils.py
+++ b/esiclient/utils.py
@@ -47,19 +47,23 @@ def get_full_network_info_from_port(port, client):
     :param port: a Neutron port
     :param client: neutron client
     """
-    names = []
+    network_names = []
+    port_names = []
     fixed_ips = []
 
-    name, fixed_ip = get_network_info_from_port(port, client)
-    names.append(name)
+    network_name, fixed_ip = get_network_info_from_port(port, client)
+    network_names.append(network_name)
     fixed_ips.append(fixed_ip)
+    port_names.append(port.name)
 
     if port.trunk_details:
         subports = port.trunk_details['sub_ports']
         for subport_info in subports:
             subport = client.get_port(subport_info['port_id'])
-            name, fixed_ip = get_network_info_from_port(subport, client)
-            names.append(name)
+            network_name, fixed_ip = get_network_info_from_port(
+                subport, client)
+            network_names.append(network_name)
             fixed_ips.append(fixed_ip)
+            port_names.append(subport.name)
 
-    return names, fixed_ips
+    return network_names, port_names, fixed_ips

--- a/esiclient/v1/node_network.py
+++ b/esiclient/v1/node_network.py
@@ -66,11 +66,12 @@ class List(command.Lister):
                 neutron_port = neutron_client.get_port(neutron_port_id)
                 network_id = neutron_port.network_id
                 if not parsed_args.network or filter_network.id == network_id:
-                    names, fixed_ips = utils.get_full_network_info_from_port(
-                        neutron_port, neutron_client)
+                    network_names, port_names, fixed_ips \
+                        = utils.get_full_network_info_from_port(
+                            neutron_port, neutron_client)
                     data.append([node.name, port.address,
                                  neutron_port.name,
-                                 "\n".join(names),
+                                 "\n".join(network_names),
                                  "\n".join(fixed_ips)])
             elif not parsed_args.network:
                 data.append([node.name, port.address, None, None, None])
@@ -196,12 +197,13 @@ class Attach(command.ShowOne):
             ironic_client.node.vif_attach(node_uuid, port.id, **vif_info)
             port = neutron_client.get_port(port.id)
 
-        names, fixed_ips = utils.get_full_network_info_from_port(
-            port, neutron_client)
+        network_names, port_names, fixed_ips \
+            = utils.get_full_network_info_from_port(
+                port, neutron_client)
 
         return ["Node", "MAC Address", "Port", "Network", "Fixed IP"], \
             [node.name, port.mac_address, port.name,
-             "\n".join(names),
+             "\n".join(network_names),
              "\n".join(fixed_ips)]
 
 

--- a/esiclient/v1/trunk.py
+++ b/esiclient/v1/trunk.py
@@ -1,0 +1,142 @@
+#   Licensed under the Apache License, Version 2.0 (the "License"); you may
+#   not use this file except in compliance with the License. You may obtain
+#   a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#   License for the specific language governing permissions and limitations
+#   under the License.
+
+import logging
+
+from osc_lib.command import command
+from osc_lib.i18n import _
+
+from esiclient import utils
+
+
+class List(command.Lister):
+    """List existing trunk ports and subports"""
+
+    log = logging.getLogger(__name__ + ".List")
+
+    def get_parser(self, prog_name):
+        parser = super(List, self).get_parser(prog_name)
+        return parser
+
+    def take_action(self, parsed_args):
+        self.log.debug("take_action(%s)" % parsed_args)
+
+        neutron_client = self.app.client_manager.network
+        trunks = neutron_client.trunks()
+
+        data = []
+        for trunk in trunks:
+            trunk_port = neutron_client.get_port(trunk.port_id)
+            network_names, port_names, fixed_ips \
+                = utils.get_full_network_info_from_port(
+                    trunk_port, neutron_client)
+            data.append([trunk.name,
+                         "\n".join(port_names),
+                         "\n".join(network_names)])
+
+        return ["Trunk", "Port", "Network"], data
+
+
+class Create(command.ShowOne):
+    """Create trunk port with subports"""
+
+    log = logging.getLogger(__name__ + ".Create")
+
+    def get_parser(self, prog_name):
+        parser = super(Create, self).get_parser(prog_name)
+        parser.add_argument(
+            "name",
+            metavar="<name>",
+            help=_("Name of trunk"))
+        parser.add_argument(
+            "--native-network",
+            metavar="<native_network>",
+            help=_("Name or UUID of the native network"))
+        parser.add_argument(
+            '--tagged-networks',
+            default=[],
+            dest='tagged_networks',
+            action='append',
+            metavar='<tagged_networks',
+            help=_("Name or UUID of tagged network")
+        )
+
+        return parser
+
+    def take_action(self, parsed_args):
+        self.log.debug("take_action(%s)" % parsed_args)
+
+        neutron_client = self.app.client_manager.network
+
+        trunk_name = parsed_args.name
+        network = neutron_client.find_network(parsed_args.native_network)
+        tagged_networks = parsed_args.tagged_networks
+
+        trunk_port = neutron_client.create_port(
+            name="{0}-{1}-trunk-port".format(trunk_name, network.name),
+            network_id=network.id
+        )
+
+        sub_ports = []
+        for tagged_network_name in tagged_networks:
+            tagged_network = neutron_client.find_network(
+                tagged_network_name)
+            sub_port = neutron_client.create_port(
+                name="{0}-{1}-sub-port".format(trunk_name,
+                                               tagged_network.name),
+                network_id=tagged_network.id
+            )
+            sub_ports.append({
+                'port_id': sub_port.id,
+                'segmentation_type': 'vlan',
+                'segmentation_id': tagged_network.provider_segmentation_id
+            })
+
+        trunk = neutron_client.create_trunk(
+            name=trunk_name,
+            port_id=trunk_port.id,
+            sub_ports=sub_ports
+        )
+
+        return ["Trunk", "Port", "Sub Ports"], \
+            [trunk.name,
+             trunk_port.name,
+             trunk.sub_ports]
+
+
+class Delete(command.Command):
+    """Delete trunk port and subports"""
+
+    log = logging.getLogger(__name__ + ".Delete")
+
+    def get_parser(self, prog_name):
+        parser = super(Delete, self).get_parser(prog_name)
+        parser.add_argument(
+            "name",
+            metavar="<name>",
+            help=_("Name of trunk"))
+
+        return parser
+
+    def take_action(self, parsed_args):
+        self.log.debug("take_action(%s)" % parsed_args)
+
+        neutron_client = self.app.client_manager.network
+        trunk = neutron_client.find_trunk(parsed_args.name)
+
+        port_ids_to_delete = [sub_port['port_id']
+                              for sub_port in trunk.sub_ports]
+        port_ids_to_delete.append(trunk.port_id)
+
+        neutron_client.delete_trunk(trunk.id)
+        for port_id in port_ids_to_delete:
+            neutron_client.delete_port(port_id)

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,3 +34,6 @@ openstack.esiclient.v1 =
     esi_node_network_attach = esiclient.v1.node_network:Attach
     esi_node_network_detach = esiclient.v1.node_network:Detach
     esi_node_network_list = esiclient.v1.node_network:List
+    esi_trunk_create = esiclient.v1.trunk:Create
+    esi_trunk_delete = esiclient.v1.trunk:Delete
+    esi_trunk_list = esiclient.v1.trunk:List


### PR DESCRIPTION
This adds list/create/delete CLI commands for managing trunk ports,
giving ESI a simplified interface.