### PR TITLE
Set device_owner to baremetal:none when creating a port

### DIFF
--- a/esiclient/tests/v1/test_node_network.py
+++ b/esiclient/tests/v1/test_node_network.py
@@ -288,7 +288,8 @@ class TestAttach(base.TestCommand):
         self.assertEqual(expected, results)
         self.app.client_manager.network.create_port.\
             assert_called_once_with(name=self.node.name,
-                                    network_id=self.network.id)
+                                    network_id=self.network.id,
+                                    device_owner='baremetal:none')
         self.app.client_manager.baremetal.node.vif_attach.\
             assert_called_once_with('node1', self.neutron_port.id)
         mock_gfnifp.assert_called_once
@@ -409,7 +410,8 @@ class TestAttach(base.TestCommand):
         self.assertEqual(expected, results)
         self.app.client_manager.network.create_port.\
             assert_called_once_with(name=self.node.name,
-                                    network_id=self.network.id)
+                                    network_id=self.network.id,
+                                    device_owner='baremetal:none')
         self.app.client_manager.baremetal.node.vif_attach.\
             assert_called_once_with('node1', self.neutron_port.id)
         self.app.client_manager.baremetal.node.vif_attach.\
@@ -450,7 +452,8 @@ class TestAttach(base.TestCommand):
         self.assertEqual(expected, results)
         self.app.client_manager.network.create_port.\
             assert_called_once_with(name=self.node.name,
-                                    network_id=self.network.id)
+                                    network_id=self.network.id,
+                                    device_owner='baremetal:none')
         self.app.client_manager.baremetal.node.vif_attach.\
             assert_called_once_with('node1', self.neutron_port.id)
         self.app.client_manager.baremetal.node.vif_attach.\

--- a/esiclient/tests/v1/test_node_volume.py
+++ b/esiclient/tests/v1/test_node_volume.py
@@ -142,7 +142,8 @@ class TestAttach(base.TestCommand):
             assert_called_once()
         self.app.client_manager.network.create_port.\
             assert_called_once_with(name='volume-node1-volume1',
-                                    network_id=self.network.id)
+                                    network_id=self.network.id,
+                                    device_owner='baremetal:none')
         self.app.client_manager.baremetal.node.vif_attach.\
             assert_called_once_with('node1', self.neutron_port.id)
         self.app.client_manager.baremetal.node.set_provision_state.\
@@ -197,7 +198,8 @@ class TestAttach(base.TestCommand):
             assert_called_once()
         self.app.client_manager.network.create_port.\
             assert_called_once_with(name='volume-node1-volume1',
-                                    network_id=self.network.id)
+                                    network_id=self.network.id,
+                                    device_owner='baremetal:none')
         self.app.client_manager.baremetal.node.vif_attach.\
             assert_called_once_with('node1', self.neutron_port.id)
         self.app.client_manager.baremetal.node.set_provision_state.\
@@ -409,7 +411,8 @@ class TestAttach(base.TestCommand):
             assert_called_once()
         self.app.client_manager.network.create_port.\
             assert_called_once_with(name='volume-node1-volume1',
-                                    network_id=self.network.id)
+                                    network_id=self.network.id,
+                                    device_owner='baremetal:none')
         self.app.client_manager.baremetal.node.vif_attach.\
             assert_called_once_with('node1', self.neutron_port.id)
         self.app.client_manager.baremetal.node.set_provision_state.\
@@ -464,7 +467,8 @@ class TestAttach(base.TestCommand):
             assert_not_called()
         self.app.client_manager.network.create_port.\
             assert_called_once_with(name='volume-node1-volume1',
-                                    network_id=self.network.id)
+                                    network_id=self.network.id,
+                                    device_owner='baremetal:none')
         self.app.client_manager.baremetal.node.vif_attach.\
             assert_called_once_with('node1', self.neutron_port.id)
         self.app.client_manager.baremetal.node.set_provision_state.\

--- a/esiclient/tests/v1/test_trunk.py
+++ b/esiclient/tests/v1/test_trunk.py
@@ -216,7 +216,7 @@ class TestCreate(base.TestCommand):
         self.app.client_manager.network.find_network.\
             side_effect = mock_find_network
 
-        def mock_create_port(name, network_id):
+        def mock_create_port(name, network_id, device_owner):
             if network_id == "network_uuid_1":
                 return self.port
             if network_id == "network_uuid_2":
@@ -254,11 +254,14 @@ class TestCreate(base.TestCommand):
         self.app.client_manager.network.create_port.\
             assert_has_calls([
                 mock.call(name="trunk-network1-trunk-port",
-                          network_id="network_uuid_1"),
+                          network_id="network_uuid_1",
+                          device_owner='baremetal:none'),
                 mock.call(name="trunk-network2-sub-port",
-                          network_id="network_uuid_2"),
+                          network_id="network_uuid_2",
+                          device_owner='baremetal:none'),
                 mock.call(name="trunk-network3-sub-port",
-                          network_id="network_uuid_3")
+                          network_id="network_uuid_3",
+                          device_owner='baremetal:none')
             ])
         self.app.client_manager.network.find_network.\
             assert_has_calls([
@@ -410,7 +413,7 @@ class TestAddNetwork(base.TestCommand):
         self.app.client_manager.network.find_network.\
             side_effect = mock_find_network
 
-        def mock_create_port(name, network_id):
+        def mock_create_port(name, network_id, device_owner):
             if network_id == "network_uuid_2":
                 return self.subport2
             if network_id == "network_uuid_3":
@@ -448,9 +451,11 @@ class TestAddNetwork(base.TestCommand):
         self.app.client_manager.network.create_port.\
             assert_has_calls([
                 mock.call(name="trunk-network2-sub-port",
-                          network_id="network_uuid_2"),
+                          network_id="network_uuid_2",
+                          device_owner='baremetal:none'),
                 mock.call(name="trunk-network3-sub-port",
-                          network_id="network_uuid_3")
+                          network_id="network_uuid_3",
+                          device_owner='baremetal:none')
             ])
         self.app.client_manager.network.find_network.\
             assert_has_calls([

--- a/esiclient/v1/node_network.py
+++ b/esiclient/v1/node_network.py
@@ -193,7 +193,8 @@ class Attach(command.ShowOne):
             print("Attaching network {1} to node {0}{2}".format(
                 node.name, network.name, mac_string))
             port = neutron_client.create_port(name=node.name,
-                                              network_id=network.id)
+                                              network_id=network.id,
+                                              device_owner='baremetal:none')
             ironic_client.node.vif_attach(node_uuid, port.id, **vif_info)
             port = neutron_client.get_port(port.id)
 

--- a/esiclient/v1/node_volume.py
+++ b/esiclient/v1/node_volume.py
@@ -147,7 +147,8 @@ class Attach(command.ShowOne):
             # create port if needed
             port = neutron_client.create_port(
                 name="volume-%s-%s" % (node.name, volume.name),
-                network_id=network.id)
+                network_id=network.id,
+                device_owner='baremetal:none')
         ironic_client.node.vif_attach(node_uuid, port.id)
 
         # deploy

--- a/esiclient/v1/trunk.py
+++ b/esiclient/v1/trunk.py
@@ -84,7 +84,8 @@ class Create(command.ShowOne):
 
         trunk_port = neutron_client.create_port(
             name="{0}-{1}-trunk-port".format(trunk_name, network.name),
-            network_id=network.id
+            network_id=network.id,
+            device_owner='baremetal:none'
         )
 
         sub_ports = []
@@ -94,7 +95,8 @@ class Create(command.ShowOne):
             sub_port = neutron_client.create_port(
                 name="{0}-{1}-sub-port".format(trunk_name,
                                                tagged_network.name),
-                network_id=tagged_network.id
+                network_id=tagged_network.id,
+                device_owner='baremetal:none'
             )
             sub_ports.append({
                 'port_id': sub_port.id,
@@ -164,7 +166,8 @@ class AddNetwork(command.ShowOne):
             sub_port = neutron_client.create_port(
                 name="{0}-{1}-sub-port".format(trunk.name,
                                                tagged_network.name),
-                network_id=tagged_network.id
+                network_id=tagged_network.id,
+                device_owner='baremetal:none'
             )
             sub_ports.append({
                 'port_id': sub_port.id,


### PR DESCRIPTION
This setting is required in order for networking-ansible to work
with a neutron port.