### PR TITLE
Delete existing volume connectors to prevent a conflict

### DIFF
--- a/esiclient/tests/v1/test_node_volume.py
+++ b/esiclient/tests/v1/test_node_volume.py
@@ -90,6 +90,8 @@ class TestAttach(base.TestCommand):
             return_value = self.node
         self.app.client_manager.baremetal.volume.volume_connector.create.\
             return_value = None
+        self.app.client_manager.baremetal.volume.volume_connector.delete.\
+            return_value = None
         self.app.client_manager.baremetal.volume.volume_target.create.\
             return_value = None
 
@@ -403,8 +405,10 @@ class TestAttach(base.TestCommand):
             assert_called_once()
         self.app.client_manager.baremetal.volume_connector.list.\
             assert_called_once_with(node='node1')
+        self.app.client_manager.baremetal.volume_connector.delete.\
+            assert_called_once()
         self.app.client_manager.baremetal.volume_connector.create.\
-            assert_not_called()
+            assert_called_once()
         self.app.client_manager.baremetal.volume_target.list.\
             assert_called_once_with(node='node1', fields=['volume_id'])
         self.app.client_manager.baremetal.volume_target.create.\

--- a/esiclient/v1/node_volume.py
+++ b/esiclient/v1/node_volume.py
@@ -114,19 +114,20 @@ class Attach(command.ShowOne):
                         'op': 'add'}]
         ironic_client.node.update(node_uuid, node_update)
 
-        # create volume connector if needed
+        # delete old volume connectors; create new one
         vcs = ironic_client.volume_connector.list(
             node=node_uuid,
         )
-        if len(vcs) == 0:
-            connector_id = 'iqn.%s.org.openstack.%s' % (
-                datetime.now().strftime('%Y-%m'),
-                node.uuid)
-            ironic_client.volume_connector.create(
-                node_uuid=node.uuid,
-                type='iqn',
-                connector_id=connector_id,
-            )
+        for vc in vcs:
+            ironic_client.volume_connector.delete(vc.uuid)
+        connector_id = 'iqn.%s.org.openstack.%s' % (
+            datetime.now().strftime('%Y-%m'),
+            uuidutils.generate_uuid())
+        ironic_client.volume_connector.create(
+            node_uuid=node.uuid,
+            type='iqn',
+            connector_id=connector_id,
+        )
 
         # create volume target if needed
         vts = [vt.volume_id for vt in


### PR DESCRIPTION
Creating a volume connector also implicitly creates a one-time
username/password through cinder that can't be retrieved or reused;
thus, using the same volume connector twice results in authentication
errors. Deleting and recreating volume connectors solves this issue.
Using a unique IQN each time prevents potential collisions as well.