### PR TITLE
Modify port creation to check if available port can be used

### DIFF
--- a/esiclient/tests/functional/v1/test_node.py
+++ b/esiclient/tests/functional/v1/test_node.py
@@ -292,7 +292,7 @@ class NodeConsoleTests(base.ESIBaseTestClass):
     def test_random_cannot_enable_console(self):
         """Tests random project console functionality.
 
-        Tests that a random project cannot perform the steps to setup an 
+        Tests that a random project cannot perform the steps to setup an
         ipmitool-socat serial console.
 
         Test steps:

--- a/esiclient/tests/unit/v1/test_node_network.py
+++ b/esiclient/tests/unit/v1/test_node_network.py
@@ -263,6 +263,8 @@ class TestAttach(base.TestCommand):
             return_value = self.neutron_port
         self.app.client_manager.network.get_port.\
             return_value = self.neutron_port
+        self.app.client_manager.network.ports.\
+            return_value = []
 
     @mock.patch('esiclient.utils.get_full_network_info_from_port',
                 return_value=(["test_network"], ["node2"],
@@ -287,7 +289,7 @@ class TestAttach(base.TestCommand):
         )
         self.assertEqual(expected, results)
         self.app.client_manager.network.create_port.\
-            assert_called_once_with(name=self.node.name,
+            assert_called_once_with(name='esi-node1-test_network',
                                     network_id=self.network.id,
                                     device_owner='baremetal:none')
         self.app.client_manager.baremetal.node.vif_attach.\

--- a/esiclient/tests/unit/v1/test_node_volume.py
+++ b/esiclient/tests/unit/v1/test_node_volume.py
@@ -86,6 +86,8 @@ class TestAttach(base.TestCommand):
             return_value = self.neutron_port
         self.app.client_manager.network.find_port.\
             return_value = self.neutron_port
+        self.app.client_manager.network.ports.\
+            return_value = []
         self.app.client_manager.baremetal.node.set_provision_state.\
             return_value = self.node
         self.app.client_manager.baremetal.volume.volume_connector.create.\
@@ -143,7 +145,7 @@ class TestAttach(base.TestCommand):
         self.app.client_manager.baremetal.volume_target.create.\
             assert_called_once()
         self.app.client_manager.network.create_port.\
-            assert_called_once_with(name='volume-node1-volume1',
+            assert_called_once_with(name='esi-node1-test_network-volume',
                                     network_id=self.network.id,
                                     device_owner='baremetal:none')
         self.app.client_manager.baremetal.node.vif_attach.\
@@ -199,7 +201,7 @@ class TestAttach(base.TestCommand):
         self.app.client_manager.baremetal.volume_target.create.\
             assert_called_once()
         self.app.client_manager.network.create_port.\
-            assert_called_once_with(name='volume-node1-volume1',
+            assert_called_once_with(name='esi-node1-test_network-volume',
                                     network_id=self.network.id,
                                     device_owner='baremetal:none')
         self.app.client_manager.baremetal.node.vif_attach.\
@@ -414,7 +416,7 @@ class TestAttach(base.TestCommand):
         self.app.client_manager.baremetal.volume_target.create.\
             assert_called_once()
         self.app.client_manager.network.create_port.\
-            assert_called_once_with(name='volume-node1-volume1',
+            assert_called_once_with(name='esi-node1-test_network-volume',
                                     network_id=self.network.id,
                                     device_owner='baremetal:none')
         self.app.client_manager.baremetal.node.vif_attach.\
@@ -470,7 +472,7 @@ class TestAttach(base.TestCommand):
         self.app.client_manager.baremetal.volume_target.create.\
             assert_not_called()
         self.app.client_manager.network.create_port.\
-            assert_called_once_with(name='volume-node1-volume1',
+            assert_called_once_with(name='esi-node1-test_network-volume',
                                     network_id=self.network.id,
                                     device_owner='baremetal:none')
         self.app.client_manager.baremetal.node.vif_attach.\

--- a/esiclient/tests/unit/v1/test_trunk.py
+++ b/esiclient/tests/unit/v1/test_trunk.py
@@ -227,6 +227,9 @@ class TestCreate(base.TestCommand):
         self.app.client_manager.network.create_port.\
             side_effect = mock_create_port
 
+        self.app.client_manager.network.ports.\
+            return_value = []
+
         self.app.client_manager.network.create_trunk.\
             return_value = self.trunk
 
@@ -253,13 +256,13 @@ class TestCreate(base.TestCommand):
         self.assertEqual(expected, results)
         self.app.client_manager.network.create_port.\
             assert_has_calls([
-                mock.call(name="trunk-network1-trunk-port",
+                mock.call(name="esi-trunk-network1-trunk-port",
                           network_id="network_uuid_1",
                           device_owner='baremetal:none'),
-                mock.call(name="trunk-network2-sub-port",
+                mock.call(name="esi-trunk-network2-sub-port",
                           network_id="network_uuid_2",
                           device_owner='baremetal:none'),
-                mock.call(name="trunk-network3-sub-port",
+                mock.call(name="esi-trunk-network3-sub-port",
                           network_id="network_uuid_3",
                           device_owner='baremetal:none')
             ])
@@ -422,6 +425,9 @@ class TestAddNetwork(base.TestCommand):
         self.app.client_manager.network.create_port.\
             side_effect = mock_create_port
 
+        self.app.client_manager.network.ports.\
+            return_value = []
+
         self.app.client_manager.network.add_trunk_subports.\
             return_value = self.trunk
 
@@ -450,10 +456,10 @@ class TestAddNetwork(base.TestCommand):
             assert_called_once_with("trunk")
         self.app.client_manager.network.create_port.\
             assert_has_calls([
-                mock.call(name="trunk-network2-sub-port",
+                mock.call(name="esi-trunk-network2-sub-port",
                           network_id="network_uuid_2",
                           device_owner='baremetal:none'),
-                mock.call(name="trunk-network3-sub-port",
+                mock.call(name="esi-trunk-network3-sub-port",
                           network_id="network_uuid_3",
                           device_owner='baremetal:none')
             ])

--- a/esiclient/utils.py
+++ b/esiclient/utils.py
@@ -67,3 +67,26 @@ def get_full_network_info_from_port(port, client):
             port_names.append(subport.name)
 
     return network_names, port_names, fixed_ips
+
+
+def get_port_name(network, prefix=None, suffix=None):
+    port_name = network.name
+    if prefix:
+        port_name = "{0}-{1}".format(prefix, port_name)
+    if suffix:
+        port_name = "{0}-{1}".format(port_name, suffix)
+    port_name = "esi-{0}".format(port_name)
+    return port_name
+
+
+def get_or_create_port(port_name, network, client):
+    ports = list(client.ports(name=port_name, status='DOWN'))
+    if len(ports) > 0:
+        port = ports[0]
+    else:
+        port = client.create_port(
+            name=port_name,
+            network_id=network.id,
+            device_owner='baremetal:none'
+        )
+    return port

--- a/esiclient/v1/node_network.py
+++ b/esiclient/v1/node_network.py
@@ -154,9 +154,8 @@ class Attach(command.ShowOne):
         else:
             print("Attaching network {1} to node {0}{2}".format(
                 node.name, network.name, mac_string))
-            port = neutron_client.create_port(name=node.name,
-                                              network_id=network.id,
-                                              device_owner='baremetal:none')
+            port_name = utils.get_port_name(network, prefix=node.name)
+            port = utils.get_or_create_port(port_name, network, neutron_client)
             ironic_client.node.vif_attach(node_uuid, port.id, **vif_info)
             port = neutron_client.get_port(port.id)
 

--- a/esiclient/v1/node_volume.py
+++ b/esiclient/v1/node_volume.py
@@ -18,6 +18,8 @@ from osc_lib import exceptions
 from osc_lib.i18n import _
 from oslo_utils import uuidutils
 
+from esiclient import utils
+
 
 AVAILABLE = 'available'
 ACTIVE = 'active'
@@ -146,10 +148,10 @@ class Attach(command.ShowOne):
         # attach node to storage network
         if not port:
             # create port if needed
-            port = neutron_client.create_port(
-                name="volume-%s-%s" % (node.name, volume.name),
-                network_id=network.id,
-                device_owner='baremetal:none')
+            port_name = utils.get_port_name(
+                network, prefix=node.name, suffix='volume')
+            port = utils.get_or_create_port(port_name, network, neutron_client)
+
         ironic_client.node.vif_attach(node_uuid, port.id)
 
         # deploy

--- a/esiclient/v1/trunk.py
+++ b/esiclient/v1/trunk.py
@@ -82,22 +82,19 @@ class Create(command.ShowOne):
         network = neutron_client.find_network(parsed_args.native_network)
         tagged_networks = parsed_args.tagged_networks
 
-        trunk_port = neutron_client.create_port(
-            name="{0}-{1}-trunk-port".format(trunk_name, network.name),
-            network_id=network.id,
-            device_owner='baremetal:none'
-        )
+        trunk_port_name = utils.get_port_name(
+            network, prefix=trunk_name, suffix='trunk-port')
+        trunk_port = utils.get_or_create_port(
+            trunk_port_name, network, neutron_client)
 
         sub_ports = []
         for tagged_network_name in tagged_networks:
             tagged_network = neutron_client.find_network(
                 tagged_network_name)
-            sub_port = neutron_client.create_port(
-                name="{0}-{1}-sub-port".format(trunk_name,
-                                               tagged_network.name),
-                network_id=tagged_network.id,
-                device_owner='baremetal:none'
-            )
+            sub_port_name = utils.get_port_name(
+                tagged_network, prefix=trunk_name, suffix='sub-port')
+            sub_port = utils.get_or_create_port(
+                sub_port_name, tagged_network, neutron_client)
             sub_ports.append({
                 'port_id': sub_port.id,
                 'segmentation_type': 'vlan',
@@ -163,12 +160,10 @@ class AddNetwork(command.ShowOne):
                 raise exceptions.CommandError(
                     "ERROR: no network named {0}".format(tagged_network_name))
 
-            sub_port = neutron_client.create_port(
-                name="{0}-{1}-sub-port".format(trunk.name,
-                                               tagged_network.name),
-                network_id=tagged_network.id,
-                device_owner='baremetal:none'
-            )
+            sub_port_name = utils.get_port_name(
+                tagged_network, prefix=trunk.name, suffix='sub-port')
+            sub_port = utils.get_or_create_port(
+                sub_port_name, tagged_network, neutron_client)
             sub_ports.append({
                 'port_id': sub_port.id,
                 'segmentation_type': 'vlan',


### PR DESCRIPTION
This change modifies port creation to use an esi-specific name,
and avoids creating a port if a port with that name already exists
and is not in use.