### PR TITLE
Set auth_required to False for mdc command

### DIFF
--- a/esiclient/v1/mdc/mdc_node_baremetal.py
+++ b/esiclient/v1/mdc/mdc_node_baremetal.py
@@ -21,6 +21,7 @@ class MDCBaremetalNodeList(command.Lister):
     """List baremetal nodes from multiple OpenStack instances"""
 
     log = logging.getLogger(__name__ + ".List")
+    auth_required = False
 
     def get_parser(self, prog_name):
         parser = super(MDCBaremetalNodeList, self).get_parser(prog_name)


### PR DESCRIPTION
The mdc CLI commands automatically use clouds.yaml; thus there
is no need to require any authentication.