### PR TITLE
Fix issue when attaching a node to a network results in no fixed ip

### DIFF
--- a/esiclient/v1/node_network.py
+++ b/esiclient/v1/node_network.py
@@ -95,10 +95,10 @@ class List(command.Lister):
                     if neutron_port.fixed_ips and \
                             len(neutron_port.fixed_ips) > 0:
                         fixed_ip = neutron_port.fixed_ips[0]['ip_address']
-                        data.append([node_name, port.address,
-                                    neutron_port.name,
-                                    network_name,
-                                    fixed_ip])
+                    data.append([node_name, port.address,
+                                 neutron_port.name,
+                                 network_name,
+                                 fixed_ip])
             elif not filter_network:
                 data.append([node_name, port.address, None, None, None])
 


### PR DESCRIPTION
There was a minor bug introduced recently; a misaligned indent meant that if a port did not have a fixed IP, it would not be represented in the node network list. This fixes that issue.