### PR TITLE
Add floating ip info in esi node network list

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.6", "3.8", "3.9"]
 
     steps:
       - uses: actions/checkout@v3

--- a/esiclient/tests/unit/test_utils.py
+++ b/esiclient/tests/unit/test_utils.py
@@ -52,6 +52,7 @@ class TestGetNetworkInfoFromPort(TestCase):
 
         self.neutron_client = mock.Mock()
         self.neutron_client.get_network.return_value = self.network
+        self.networks_dict = {"network_uuid": self.network}
 
     def test_get_network_info_from_port(self):
         port = test_utils.create_mock_object({
@@ -61,7 +62,8 @@ class TestGetNetworkInfoFromPort(TestCase):
             "fixed_ips": [{"ip_address": '11.22.33.44'}]
         })
 
-        results = utils.get_network_info_from_port(port, self.neutron_client)
+        results = utils.get_network_info_from_port(port, self.neutron_client,
+                                                   self.networks_dict)
         self.assertEqual(('test_network (777)', '11.22.33.44'), results)
 
     def test_get_network_info_from_port_no_fixed_ips(self):
@@ -72,7 +74,8 @@ class TestGetNetworkInfoFromPort(TestCase):
             "fixed_ips": None
         })
 
-        results = utils.get_network_info_from_port(port, self.neutron_client)
+        results = utils.get_network_info_from_port(port, self.neutron_client,
+                                                   self.networks_dict)
         self.assertEqual(('test_network (777)', ''), results)
 
 
@@ -104,6 +107,9 @@ class TestGetFullNetworkInfoFromPort(TestCase):
         })
 
         self.neutron_client = mock.Mock()
+
+        self.networks_dict = {"network_uuid_1": self.network1,
+                              "network_uuid_2": self.network2}
 
         def mock_network_get(network_uuid):
             if network_uuid == "network_uuid_1":
@@ -137,7 +143,8 @@ class TestGetFullNetworkInfoFromPort(TestCase):
         })
 
         results = utils.get_full_network_info_from_port(port,
-                                                        self.neutron_client)
+                                                        self.neutron_client,
+                                                        self.networks_dict,)
         self.assertEqual((
             ['test_network (777)', 'test_network (777)',
              'test_network_2 (888)'],
@@ -155,7 +162,8 @@ class TestGetFullNetworkInfoFromPort(TestCase):
         })
 
         results = utils.get_full_network_info_from_port(port,
-                                                        self.neutron_client)
+                                                        self.neutron_client,
+                                                        self.networks_dict)
         self.assertEqual(
             (['test_network (777)'], ['test_port'], ['77.77.77.77']),
             results

--- a/esiclient/tests/unit/v1/test_switch.py
+++ b/esiclient/tests/unit/v1/test_switch.py
@@ -227,11 +227,13 @@ class TestListSwitchPort(base.TestCommand):
         self.app.client_manager.baremetal.port.list.\
             return_value = [self.port1, self.port2, self.port3, self.port4,
                             self.port5]
+        self.app.client_manager.network.networks.\
+            return_value = []
 
     @mock.patch('esiclient.utils.get_full_network_info_from_port',
                 autospec=True)
     def test_take_action(self, mock_gfnifp):
-        def mock_gfnifp_call(np, client):
+        def mock_gfnifp_call(np, n_dict, client):
             if np.id == 'neutron_port_uuid_1':
                 return ['net1 (100)', 'net2 (200)'], [], []
             elif np.id == 'neutron_port_uuid_2':

--- a/esiclient/tests/unit/v1/test_trunk.py
+++ b/esiclient/tests/unit/v1/test_trunk.py
@@ -88,6 +88,8 @@ class TestList(base.TestCommand):
 
         self.app.client_manager.network.trunks.\
             return_value = [self.trunk1, self.trunk2]
+        self.app.client_manager.network.networks.\
+            return_value = []
 
         def mock_get_port(port_id):
             if port_id == "port_uuid_1":
@@ -101,7 +103,7 @@ class TestList(base.TestCommand):
     @mock.patch('esiclient.utils.get_full_network_info_from_port',
                 autospec=True)
     def test_take_action(self, mock_gfnifp):
-        def mock_get_fnifp(port, client):
+        def mock_get_fnifp(port, n_dict, client):
             if port.id == "port_uuid_1":
                 return (["network1", "network2", "network3"],
                         ["trunk1-network1-trunk-port",
@@ -143,8 +145,8 @@ class TestList(base.TestCommand):
                 mock.call("port_uuid_4")
             ])
         mock_gfnifp.assert_has_calls([
-                mock.call(self.port1, self.app.client_manager.network),
-                mock.call(self.port2, self.app.client_manager.network)
+                mock.call(self.port1, self.app.client_manager.network, {}),
+                mock.call(self.port2, self.app.client_manager.network, {})
             ])
 
 

--- a/esiclient/v1/switch.py
+++ b/esiclient/v1/switch.py
@@ -105,6 +105,8 @@ class ListSwitchPort(command.Lister):
                       if port.local_link_connection.get(
                               'switch_info') == switch))
         neutron_ports = list(neutron_client.ports())
+        networks = list(neutron_client.networks())
+        networks_dict = {n.id: n for n in networks}
 
         data = []
         for port in ports:
@@ -117,7 +119,7 @@ class ListSwitchPort(command.Lister):
             if np:
                 network_names, _, _ = \
                     utils.get_full_network_info_from_port(
-                        np, neutron_client)
+                        np, neutron_client, networks_dict)
             data.append([switchport, "\n".join(network_names)])
         return ["Port", "VLANs"], data
 

--- a/esiclient/v1/trunk.py
+++ b/esiclient/v1/trunk.py
@@ -33,13 +33,15 @@ class List(command.Lister):
 
         neutron_client = self.app.client_manager.network
         trunks = neutron_client.trunks()
+        networks = list(neutron_client.networks())
+        networks_dict = {n.id: n for n in networks}
 
         data = []
         for trunk in trunks:
             trunk_port = neutron_client.get_port(trunk.port_id)
             network_names, port_names, _ \
                 = utils.get_full_network_info_from_port(
-                    trunk_port, neutron_client)
+                    trunk_port, neutron_client, networks_dict)
             data.append([trunk.name,
                          "\n".join(port_names),
                          "\n".join(network_names)])

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 minversion = 3.2.0
 envlist = pep8,py37,py36
 skipsdist = True
+ignore_basepython_conflict = true
 
 [testenv]
 basepython = python3


### PR DESCRIPTION
1. Expand 'openstack esi node network list' output to  Node|MAC Address|Port |Network|Fixed IP|Floating IP|Floating Network
2. Reduce neutron /networks/id API calls by fetching all networks at once and then convert the network list into a dict {network_id: network_obj}. 