### PR TITLE
Enforce openstacksdk<1.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@
 pbr!=2.1.0,>=2.0.0 # Apache-2.0
 
 Babel!=2.4.0,>=2.3.4 # BSD
+openstacksdk<1.3.0
 pbr!=2.1.0,>=2.0.0 # Apache-2.0
 passlib>=1.7.0 # BSD
 psutil>=3.2.2 # BSD


### PR DESCRIPTION
This is needed to support older versions of python3