### PR TITLE
node network list now calls from esisdk

### DIFF
--- a/esiclient/tests/unit/v1/test_node_network.py
+++ b/esiclient/tests/unit/v1/test_node_network.py
@@ -24,7 +24,6 @@ class TestList(base.TestCommand):
 
     def setUp(self):
         super(TestList, self).setUp()
-        self.cmd = node_network.List(self.app, None)
 
         self.port1 = utils.create_mock_object({
             "uuid": "port_uuid_1",
@@ -50,6 +49,12 @@ class TestList(base.TestCommand):
             "address": "dd:dd:dd:dd:dd:dd",
             "internal_info": {'tenant_vif_port_id': 'neutron_port_uuid_4'}
         })
+        self.port5 = utils.create_mock_object({
+            'uuid': 'port_uuid_5',
+            'node_uuid': '11111111-2222-3333-4444-bbbbbbbbbbbb',
+            'address': 'ee:ee:ee:ee:ee:ee',
+            'internal_info': {'tenant_vif_port_id': 'neutron_port_uuid_3'}
+        })
         self.node1 = utils.create_mock_object({
             "uuid": "11111111-2222-3333-4444-aaaaaaaaaaaa",
             "name": "node1"
@@ -58,39 +63,83 @@ class TestList(base.TestCommand):
             "uuid": "11111111-2222-3333-4444-bbbbbbbbbbbb",
             "name": "node2"
         })
-        self.network = utils.create_mock_object({
-            "id": "network_uuid",
-            "name": "test_network"
+        self.network1 = utils.create_mock_object({
+            "id": "network_uuid_1",
+            "name": "test_network_1"
+        })
+        self.network2 = utils.create_mock_object({
+            "id": "network_uuid_2",
+            "name": "test_network_2"
+        })
+        self.network3 = utils.create_mock_object({
+            "id": "network_uuid_3",
+            "name": "test_network_3"
         })
         self.neutron_port1 = utils.create_mock_object({
             "id": "neutron_port_uuid_1",
-            "network_id": "network_uuid",
+            "network_id": "network_uuid_1",
             "name": "neutron_port_1",
             "fixed_ips": [{"ip_address": "1.1.1.1"}],
             "trunk_details": None
         })
         self.neutron_port2 = utils.create_mock_object({
             "id": "neutron_port_uuid_2",
-            "network_id": "network_uuid",
+            "network_id": "network_uuid_1",
             "name": "neutron_port_2",
             "fixed_ips": [{"ip_address": "2.2.2.2"}],
             "trunk_details": None
         })
-        self.floating_network = utils.create_mock_object({
-            "id": "floating_network_id",
-            "name": "floating_network"
+        self.neutron_port3 = utils.create_mock_object({
+            'id': 'neutron_port_uuid_3',
+            'network_id': 'network_uuid_3',
+            'name': 'neutron_port_3',
+            'fixed_ips': [{'ip_address': '3.3.3.3'}],
+            'trunk_details': {
+                'sub_ports': [
+                    {'port_id': 'subport_uuid_1'},
+                    {'port_id': 'subport_uuid_2'},
+                ]
+            }
+        })
+        self.subport_1 = utils.create_mock_object({
+            'id': 'subport_uuid_1',
+            'network_id': 'network_uuid_1',
+            'name': 'subport_1',
+            'fixed_ips': [{'ip_address': '4.4.4.4'}],
+            'trunk_details': {}
+        })
+        self.subport_2 = utils.create_mock_object({
+            'id': 'subport_uuid_2',
+            'network_id': 'network_uuid_2',
+            'name': 'subport_2',
+            'fixed_ips': [{'ip_address': '5.5.5.5'}],
+            'trunk_details': {}
+        })
+        self.floating_network1 = utils.create_mock_object({
+            "id": "floating_network_id_1",
+            "name": "floating_network_1"
+        })
+        self.floating_network2 = utils.create_mock_object({
+            "id": "floating_network_id_2",
+            "name": "floating_network_2"
         })
         self.floating_ip = utils.create_mock_object({
             "id": "floating_ip_uuid_2",
             "floating_ip_address": "8.8.8.8",
-            "floating_network_id": "floating_network_id",
+            "floating_network_id": "floating_network_id_1",
             "port_id": "neutron_port_uuid_2"
         })
         self.floating_ip_pfw = utils.create_mock_object({
             "id": "floating_ip_uuid_1",
             "floating_ip_address": "9.9.9.9",
-            "floating_network_id": "floating_network_id",
+            "floating_network_id": "floating_network_id_1",
             "port_id": None
+        })
+        self.floating_ip2 = utils.create_mock_object({
+            'id': 'floating_ip uuid_3',
+            'floating_ip_address': '10.10.10.10',
+            'floating_network_id': 'floating_network_id_2',
+            'port_id': None
         })
         self.pfw1 = utils.create_mock_object({
             "internal_port": 22,
@@ -102,153 +151,443 @@ class TestList(base.TestCommand):
             "external_port": 23,
             "internal_port_id": "neutron_port_uuid_1"
         })
+        self.pfw3 = utils.create_mock_object({
+            "internal_port": 24,
+            "external_port": 24,
+            "internal_port_id": "neutron_port_uuid_3"
+        })
 
-        def mock_node_get(node_uuid):
-            if node_uuid == "11111111-2222-3333-4444-aaaaaaaaaaaa":
-                return self.node1
-            elif node_uuid == "11111111-2222-3333-4444-bbbbbbbbbbbb":
-                return self.node2
-            return None
-        self.app.client_manager.baremetal.node.get.side_effect = mock_node_get
+        self.cmd = node_network.List(self.app, None)
 
-        def mock_neutron_port_get(port_uuid):
-            if port_uuid == "neutron_port_uuid_1":
-                return self.neutron_port1
-            elif port_uuid == "neutron_port_uuid_2":
-                return self.neutron_port2
-            return None
-        self.app.client_manager.network.get_port.\
-            side_effect = mock_neutron_port_get
+    @mock.patch('esiclient.utils.get_network_display_name')
+    @mock.patch('esi.lib.nodes.network_list')
+    def test_take_action_no_network(self,
+                                    mock_network_list,
+                                    mock_get_network_display_name):
+        mock_network_list.return_value = [
+            {
+                'node': self.node1,
+                'network_info': [
+                    {
+                        'baremetal_port': self.port1,
+                        'network_ports': [],
+                        'networks': {
+                            'parent': None,
+                            'trunk': [],
+                            'floating': None,
+                        },
+                        'floating_ip': None,
+                        'port_forwardings': []
+                    }
+                ]
+            }
+        ]
 
-        def mock_neutron_port_forwardings(fip):
-            if fip.id == "floating_ip_uuid_1":
-                return [self.pfw1, self.pfw2]
-            return []
-        self.app.client_manager.network.port_forwardings.\
-            side_effect = mock_neutron_port_forwardings
-
-        self.app.client_manager.network.find_network.\
-            return_value = self.network
-        self.app.client_manager.network.get_network.\
-            return_value = self.network
-        self.app.client_manager.network.ports.\
-            return_value = [self.neutron_port1, self.neutron_port2]
-        self.app.client_manager.network.networks.\
-            return_value = [self.network, self.floating_network]
-        self.app.client_manager.baremetal.node.list.\
-            return_value = [self.node1, self.node2]
-        self.app.client_manager.network.ips.\
-            return_value = [self.floating_ip, self.floating_ip_pfw]
-
-    def test_take_action(self):
-        self.app.client_manager.baremetal.port.list.\
-            return_value = [self.port1, self.port2, self.port3]
+        mock_get_network_display_name.\
+            side_effect = lambda network: network.name
 
         arglist = []
         verifylist = []
-
         parsed_args = self.check_parser(self.cmd, arglist, verifylist)
 
         results = self.cmd.take_action(parsed_args)
-        expected = (
-          ["Node", "MAC Address", "Port", "Network", "Fixed IP",
-           "Floating Network", "Floating IP"],
-          [['node1', 'aa:aa:aa:aa:aa:aa', 'neutron_port_1', 'test_network',
-           '1.1.1.1', 'floating_network', '9.9.9.9 (22:22,23:23)'],
-           ['node2', 'bb:bb:bb:bb:bb:bb', None, None, None, None, None],
-           ['node2', 'cc:cc:cc:cc:cc:cc', 'neutron_port_2', 'test_network',
-            '2.2.2.2', 'floating_network', '8.8.8.8']]
-        )
-        self.assertEqual(expected, results)
-        self.app.client_manager.baremetal.port.list.\
-            assert_called_once_with(detail=True)
 
-    def test_take_action_neutron_port_does_not_exist(self):
-        self.app.client_manager.baremetal.port.list.\
-            return_value = [self.port4]
+        data = [
+            [
+                'node1',
+                'aa:aa:aa:aa:aa:aa',
+                None,
+                None,
+                None,
+                None,
+                None,
+            ]
+        ]
+
+        expected = ["Node", "MAC Address", "Port", "Network", "Fixed IP",
+                    "Floating Network", "Floating IP"], data
+
+        self.assertEqual(expected, results)
+        mock_get_network_display_name.assert_not_called()
+
+    @mock.patch('esiclient.utils.get_network_display_name')
+    @mock.patch('esi.lib.nodes.network_list')
+    def test_take_action_multiple_nodes(self,
+                                        mock_network_list,
+                                        mock_get_network_display_name):
+        mock_network_list.return_value = [
+            {
+                'node': self.node1,
+                'network_info': [
+                    {
+                        'baremetal_port': self.port1,
+                        'network_ports': [],
+                        'networks': {
+                            'parent': None,
+                            'trunk': [],
+                            'floating': None,
+                        },
+                        'floating_ip': None,
+                        'port_forwardings': []
+                    }
+                ]
+            },
+            {
+                'node': self.node2,
+                'network_info': [
+                    {
+                        'baremetal_port': self.port3,
+                        'network_ports': [self.neutron_port2],
+                        'networks': {
+                            'parent': self.network1,
+                            'trunk': [],
+                            'floating': self.floating_network1,
+                        },
+                        'floating_ip': self.floating_ip,
+                        'port_forwardings': []
+                    }
+                ]
+            }
+        ]
+
+        mock_get_network_display_name.\
+            side_effect = lambda network: network.name
 
         arglist = []
         verifylist = []
-
         parsed_args = self.check_parser(self.cmd, arglist, verifylist)
 
         results = self.cmd.take_action(parsed_args)
-        expected = (
-            ["Node", "MAC Address", "Port", "Network", "Fixed IP",
-             "Floating Network", "Floating IP"],
-            [["node2", "dd:dd:dd:dd:dd:dd", None, None, None, None, None]]
-        )
+
+        data = [
+            [
+                'node1',
+                'aa:aa:aa:aa:aa:aa',
+                None,
+                None,
+                None,
+                None,
+                None,
+            ],
+            [
+                'node2',
+                'cc:cc:cc:cc:cc:cc',
+                'neutron_port_2',
+                'test_network_1',
+                '2.2.2.2',
+                'floating_network_1',
+                '8.8.8.8'
+            ]
+        ]
+
+        expected = ["Node", "MAC Address", "Port", "Network", "Fixed IP",
+                    "Floating Network", "Floating IP"], data
+
         self.assertEqual(expected, results)
-        self.app.client_manager.baremetal.port.list.\
-            assert_called_once_with(detail=True)
+        mock_get_network_display_name.assert_has_calls([
+            mock.call(self.network1),
+            mock.call(self.floating_network1),
+        ])
 
-    def test_take_action_node_filter(self):
-        self.app.client_manager.baremetal.port.list.\
-            return_value = [self.port2, self.port3]
+    @mock.patch('esiclient.utils.get_network_display_name')
+    @mock.patch('esi.lib.nodes.network_list')
+    def test_take_action_multiple_ports(self,
+                                        mock_network_list,
+                                        mock_get_network_display_name):
+        mock_network_list.return_value = [
+            {
+                'node': self.node2,
+                'network_info': [
+                    {
+                        'baremetal_port': self.port2,
+                        'network_ports': [],
+                        'networks': {
+                            'parent': None,
+                            'trunk': [],
+                            'floating': None
+                        },
+                        'floating_ip': None,
+                        'port_forwardings': []
+                    },
+                    {
+                        'baremetal_port': self.port3,
+                        'network_ports': [self.neutron_port2],
+                        'networks': {
+                            'parent': self.network1,
+                            'trunk': [],
+                            'floating': self.floating_network1
+                        },
+                        'floating_ip': self.floating_ip,
+                        'port_forwardings': []
+                    }
+                ]
+            }
+        ]
 
-        arglist = ['--node', '11111111-2222-3333-4444-bbbbbbbbbbbb']
+        mock_get_network_display_name.\
+            side_effect = lambda network: network.name
+
+        arglist = []
         verifylist = []
-
         parsed_args = self.check_parser(self.cmd, arglist, verifylist)
 
         results = self.cmd.take_action(parsed_args)
-        expected = (
-           ["Node", "MAC Address", "Port", "Network", "Fixed IP",
-            "Floating Network", "Floating IP"],
-           [['node2', 'bb:bb:bb:bb:bb:bb', None, None, None, None, None],
-            ['node2', 'cc:cc:cc:cc:cc:cc', 'neutron_port_2', 'test_network',
-             '2.2.2.2', 'floating_network', '8.8.8.8']]
-        )
+
+        data = [
+            [
+                'node2',
+                'bb:bb:bb:bb:bb:bb',
+                None,
+                None,
+                None,
+                None,
+                None,
+            ],
+            [
+                'node2',
+                'cc:cc:cc:cc:cc:cc',
+                'neutron_port_2',
+                'test_network_1',
+                '2.2.2.2',
+                'floating_network_1',
+                '8.8.8.8'
+            ]
+        ]
+
+        expected = ["Node", "MAC Address", "Port", "Network", "Fixed IP",
+                    "Floating Network", "Floating IP"], data
+
         self.assertEqual(expected, results)
-        self.app.client_manager.baremetal.port.list.\
-            assert_called_once_with(
-                node="11111111-2222-3333-4444-bbbbbbbbbbbb", detail=True)
+        mock_get_network_display_name.assert_has_calls([
+            mock.call(self.network1),
+            mock.call(self.floating_network1),
+        ])
 
-    def test_take_action_network_filter(self):
+    @mock.patch('esiclient.utils.get_network_display_name')
+    @mock.patch('esi.lib.nodes.network_list')
+    def test_take_action_port_forwardings(self,
+                                          mock_network_list,
+                                          mock_get_network_display_name):
+        mock_network_list.return_value = [
+            {
+                'node': self.node1,
+                'network_info': [
+                    {
+                        'baremetal_port': self.port1,
+                        'network_ports': [self.neutron_port1],
+                        'networks': {
+                            'parent': self.network1,
+                            'trunk': [],
+                            'floating': self.floating_network1,
+                        },
+                        'floating_ip': self.floating_ip_pfw,
+                        'port_forwardings': [self.pfw1, self.pfw2]
+                    }
+                ]
+            }
+        ]
 
-        self.app.client_manager.baremetal.port.list.\
-            return_value = [self.port1, self.port2, self.port3]
+        mock_get_network_display_name.\
+            side_effect = lambda network: network.name
 
-        arglist = ['--network', 'network']
+        arglist = []
         verifylist = []
-
         parsed_args = self.check_parser(self.cmd, arglist, verifylist)
 
         results = self.cmd.take_action(parsed_args)
-        expected = (
-            ["Node", "MAC Address", "Port", "Network", "Fixed IP",
-             "Floating Network", "Floating IP"],
-            [["node1", "aa:aa:aa:aa:aa:aa",
-              "neutron_port_1", "test_network", "1.1.1.1",
-              "floating_network", "9.9.9.9 (22:22,23:23)"],
-             ["node2", "cc:cc:cc:cc:cc:cc",
-              "neutron_port_2", "test_network", "2.2.2.2",
-              "floating_network", "8.8.8.8"]]
-        )
+
+        data = [
+            [
+                'node1',
+                'aa:aa:aa:aa:aa:aa',
+                'neutron_port_1',
+                'test_network_1',
+                '1.1.1.1',
+                'floating_network_1',
+                '9.9.9.9 (22:22,23:23)'
+            ]
+        ]
+
+        expected = ["Node", "MAC Address", "Port", "Network", "Fixed IP",
+                    "Floating Network", "Floating IP"], data
+
         self.assertEqual(expected, results)
-        self.app.client_manager.baremetal.port.list.\
-            assert_called_once_with(detail=True)
+        mock_get_network_display_name.assert_has_calls([
+            mock.call(self.network1),
+            mock.call(self.floating_network1),
+        ])
 
-    def test_take_action_node_network_filter(self):
-        self.app.client_manager.baremetal.port.list.\
-            return_value = [self.port2, self.port3]
+    @mock.patch('esiclient.utils.get_network_display_name')
+    @mock.patch('esi.lib.nodes.network_list')
+    def test_take_action_trunk(self,
+                               mock_network_list,
+                               mock_get_network_display_name):
+        mock_network_list.return_value = [
+            {
+                'node': self.node2,
+                'network_info': [
+                    {
+                        'baremetal_port': self.port5,
+                        'network_ports': [
+                            self.neutron_port3,
+                            self.subport_1,
+                            self.subport_2
+                        ],
+                        'networks': {
+                            'parent': self.network3,
+                            'trunk': [
+                                self.network1,
+                                self.network2
+                            ],
+                            'floating': None
+                        },
+                        'floating_ip': None,
+                        'port_forwardings': []
+                    }
+                ]
+            }
+        ]
 
-        arglist = ['--node', 'node2', '--network', 'network']
+        mock_get_network_display_name.\
+            side_effect = lambda network: network.name
+
+        arglist = []
         verifylist = []
-
         parsed_args = self.check_parser(self.cmd, arglist, verifylist)
 
         results = self.cmd.take_action(parsed_args)
-        expected = (
-            ["Node", "MAC Address", "Port", "Network", "Fixed IP",
-             "Floating Network", "Floating IP"],
-            [["node2", "cc:cc:cc:cc:cc:cc",
-              "neutron_port_2", "test_network", "2.2.2.2",
-              "floating_network", "8.8.8.8"]]
-        )
+
+        data = [
+            [
+                'node2',
+                'ee:ee:ee:ee:ee:ee',
+                'neutron_port_3',
+                'test_network_3\ntest_network_1\ntest_network_2',
+                '3.3.3.3\n4.4.4.4\n5.5.5.5',
+                None,
+                None
+            ]
+        ]
+
+        expected = ["Node", "MAC Address", "Port", "Network", "Fixed IP",
+                    "Floating Network", "Floating IP"], data
+
         self.assertEqual(expected, results)
-        self.app.client_manager.baremetal.port.list.\
-            assert_called_once_with(node="node2", detail=True)
+        mock_get_network_display_name.assert_has_calls([
+            mock.call(self.network3),
+            mock.call(self.network1),
+            mock.call(self.network2),
+        ])
+
+    @mock.patch('esiclient.utils.get_network_display_name')
+    @mock.patch('esi.lib.nodes.network_list')
+    def test_take_action(self,
+                         mock_network_list,
+                         mock_get_network_display_name):
+        mock_network_list.return_value = [
+            {
+                'node': self.node1,
+                'network_info': [
+                    {
+                        'baremetal_port': self.port1,
+                        'network_ports': [self.neutron_port1],
+                        'networks': {
+                            'parent': self.network1,
+                            'trunk': [],
+                            'floating': self.floating_network1,
+                        },
+                        'floating_ip': self.floating_ip_pfw,
+                        'port_forwardings': [self.pfw1, self.pfw2]
+                    }
+                ]
+            },
+            {
+                'node': self.node2,
+                'network_info': [
+                    {
+                        'baremetal_port': self.port2,
+                        'network_ports': [],
+                        'networks': {
+                            'parent': None,
+                            'trunk': [],
+                            'floating': None
+                        },
+                        'floating_ip': None,
+                        'port_forwardings': []
+                    },
+                    {
+                        'baremetal_port': self.port5,
+                        'network_ports': [
+                            self.neutron_port3,
+                            self.subport_1,
+                            self.subport_2
+                        ],
+                        'networks': {
+                            'parent': self.network3,
+                            'trunk': [
+                                self.network1,
+                                self.network2
+                            ],
+                            'floating': self.floating_network2
+                        },
+                        'floating_ip': self.floating_ip2,
+                        'port_forwardings': [self.pfw3]
+                    }
+                ]
+            }
+        ]
+
+        mock_get_network_display_name.\
+            side_effect = lambda network: network.name
+
+        arglist = []
+        verifylist = []
+        parsed_args = self.check_parser(self.cmd, arglist, verifylist)
+
+        results = self.cmd.take_action(parsed_args)
+
+        data = [
+            [
+                'node1',
+                'aa:aa:aa:aa:aa:aa',
+                'neutron_port_1',
+                'test_network_1',
+                '1.1.1.1',
+                'floating_network_1',
+                '9.9.9.9 (22:22,23:23)'
+            ],
+            [
+                'node2',
+                'bb:bb:bb:bb:bb:bb',
+                None,
+                None,
+                None,
+                None,
+                None
+            ],
+            [
+                'node2',
+                'ee:ee:ee:ee:ee:ee',
+                'neutron_port_3',
+                'test_network_3\ntest_network_1\ntest_network_2',
+                '3.3.3.3\n4.4.4.4\n5.5.5.5',
+                'floating_network_2',
+                '10.10.10.10 (24:24)'
+            ]
+        ]
+
+        expected = ["Node", "MAC Address", "Port", "Network", "Fixed IP",
+                    "Floating Network", "Floating IP"], data
+
+        self.assertEqual(expected, results)
+        mock_get_network_display_name.assert_has_calls([
+            mock.call(self.network1),
+            mock.call(self.floating_network1),
+            mock.call(self.network3),
+            mock.call(self.network1),
+            mock.call(self.network2),
+            mock.call(self.floating_network2),
+        ])
 
 
 class TestAttach(base.TestCommand):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@
 pbr!=2.1.0,>=2.0.0 # Apache-2.0
 
 Babel!=2.4.0,>=2.3.4 # BSD
+esisdk>=0.4.0 # Apache 2.0
 metalsmith>=2.0.0
 openstacksdk<1.3.0
 oslo.utils>=4.5.0 # Apache-2.0
@@ -16,6 +17,5 @@ python-openstackclient>=5.2.0 # Apache-2.0
 simplejson>=3.5.1 # MIT
 six>=1.10.0 # MIT
 osc-lib>=1.8.0 # Apache-2.0
-oslo.utils>=3.33.0 # Apache-2.0
 websocket-client>=0.44.0 # LGPLv2+
 ansible-runner>=1.4.4 # Apache 2.0


### PR DESCRIPTION
To centralize logic, the `esi node network list` will call from esisdk.