### PR TITLE
Teach node network detach about --all option

### DIFF
--- a/esiclient/v1/node_network.py
+++ b/esiclient/v1/node_network.py
@@ -256,7 +256,14 @@ class Detach(command.Command):
             "node", metavar="<node>", help=_("Name or UUID of the node")
         )
         parser.add_argument(
-            "--port", metavar="<port>", help=_("Name or UUID of the port")
+            "--port",
+            metavar="<port>",
+            help=_("Name or UUID of the port"),
+            action="append",
+            default=[],
+        )
+        parser.add_argument(
+            "--all", action="store_true", help=_("Detach all ports from node")
         )
 
         return parser
@@ -265,5 +272,8 @@ class Detach(command.Command):
         self.log.debug("take_action(%s)", parsed_args)
 
         nodes.network_detach(
-            self.app.client_manager.sdk_connection, parsed_args.node, parsed_args.port
+            self.app.client_manager.sdk_connection,
+            parsed_args.node,
+            port_names_or_uuids=parsed_args.port,
+            all_ports=parsed_args.all,
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 pbr!=2.1.0,>=2.0.0 # Apache-2.0
 
 Babel!=2.4.0,>=2.3.4 # BSD
-esisdk>=0.5.0 # Apache 2.0
+esisdk>=1.4 # Apache-2.0
 metalsmith>=2.0.0
 openstacksdk<1.3.0
 oslo.utils>=4.5.0 # Apache-2.0


### PR DESCRIPTION
Update python-esiclient for compatability with the changes introduced in
cci-moc/esisdk#15. This adds support for the `--all` option (delete all
ports), and also permits the `--port` option to be used multiple times
to delete multiple individual ports.
