### PR TITLE
Fix type checks

### DIFF
--- a/esiclient/tests/functional/base.py
+++ b/esiclient/tests/functional/base.py
@@ -152,10 +152,10 @@ class ESIBaseTestClass(base.ClientTestBase):
             'domain': 'default'
         }
 
-        if roles is []:
+        if not roles:
             raise ValueError('No roles specified when initializing dummy \
                               project %s' % name)
-        elif type(roles) is str:
+        elif isinstance(roles, str):
             roles = [roles]
 
         for role in roles:

--- a/esiclient/tests/functional/utils.py
+++ b/esiclient/tests/functional/utils.py
@@ -39,9 +39,9 @@ def kwargs_to_flags(valid_flags, arguments):
         if val is not None:
             if flag in valid_flags:
                 tmp = ' --%s' % flag.replace('_', '-')
-                if type(val) == str:
+                if isinstance(val, str):
                     flag_string += '%s "%s"' % (tmp, val)
-                elif type(val) == bool:
+                elif isinstance(val, bool):
                     flag_string += tmp if val else ''
                 else:
                     raise TypeError('Invalid value for flag %s, expected \


### PR DESCRIPTION
The esiclient code contained a number of questionable type comparisons,
like this:

    if type(var) == "str":
        ...

But this is problematic, and can fail if what you've received is actually a
subclass of the target type. In general, we should always use
`isinstance()` for checking the type of a variable.

See also the documentation on flake8 rule E721 [1].

[1]: https://www.flake8rules.com/rules/E721.html
