### PR TITLE
Remove version requirement for openstacksdk

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ pbr!=2.1.0,>=2.0.0 # Apache-2.0
 Babel!=2.4.0,>=2.3.4 # BSD
 esisdk>=1.4 # Apache-2.0
 metalsmith>=2.0.0
-openstacksdk<1.3.0
+openstacksdk
 oslo.utils>=4.5.0 # Apache-2.0
 pbr!=2.1.0,>=2.0.0 # Apache-2.0
 passlib>=1.7.0 # BSD


### PR DESCRIPTION
The `openstacksdk<1.3.0` requirement was to maintain compatibility with older versions of python we no longer support; it also results in impossible dependencies caused by newer openstack clients requiring newer versions of openstacksdk.