### PR TITLE
Update test OS to Ubuntu 24.04

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]


### PR DESCRIPTION
Ubuntu 20.04 was deprecated on 2025-04-15; this updates the version of Ubuntu we use.