### PR TITLE
Improve error handling in ..esi trunk create

### DIFF
--- a/esiclient/tests/unit/v1/test_trunk.py
+++ b/esiclient/tests/unit/v1/test_trunk.py
@@ -253,7 +253,7 @@ class TestCreate(base.TestCommand):
         self.assertEqual(expected, results)
         self.app.client_manager.network.find_network.assert_has_calls(
             [
-                mock.call("network1"),
+                mock.call("network1", ignore_missing=False),
             ]
         )
         mock_create_trunk.assert_called_once_with(

--- a/esiclient/v1/trunk.py
+++ b/esiclient/v1/trunk.py
@@ -77,7 +77,9 @@ class Create(command.ShowOne):
         neutron_client = self.app.client_manager.network
 
         trunk_name = parsed_args.name
-        network = neutron_client.find_network(parsed_args.native_network)
+        network = neutron_client.find_network(
+            parsed_args.native_network, ignore_missing=False
+        )
         tagged_networks = parsed_args.tagged_networks
 
         trunk, trunk_port = utils.create_trunk(


### PR DESCRIPTION

Allows Neutron's  error messages to surface properly during invalid network references.
- Use `ignore_missing=False` in find_network to raise OpenStack SDK errors
- Removes silent fallback to None