### PR TITLE
Make the "port forwarding create" command idempotent

### DIFF
--- a/esiclient/tests/unit/v1/test_port_forwarding.py
+++ b/esiclient/tests/unit/v1/test_port_forwarding.py
@@ -27,6 +27,7 @@ class PortForwardTestCase(testtools.TestCase):
             name="floating_ip_1",
             id="floating_ip_1",
             floating_ip_address="111.111.111.111",
+            port_forwardings=[],
         )
         self.forward_1 = mock.Mock(
             name="port_forwarding_1",
@@ -40,13 +41,25 @@ class PortForwardTestCase(testtools.TestCase):
 
 class TestPortSpec(testtools.TestCase):
     test_params = (
-        ("22", True, PortSpec(int_port=22, ext_port=22, protocol=Protocol.TCP)),
-        ("22/udp", True, PortSpec(int_port=22, ext_port=22, protocol=Protocol.UDP)),
-        ("2222:22", True, PortSpec(int_port=22, ext_port=2222, protocol=Protocol.TCP)),
+        (
+            "22",
+            True,
+            PortSpec(internal_port=22, external_port=22, protocol=Protocol.TCP),
+        ),
+        (
+            "22/udp",
+            True,
+            PortSpec(internal_port=22, external_port=22, protocol=Protocol.UDP),
+        ),
+        (
+            "2222:22",
+            True,
+            PortSpec(internal_port=22, external_port=2222, protocol=Protocol.TCP),
+        ),
         (
             "2222:22/tcp",
             True,
-            PortSpec(int_port=22, ext_port=2222, protocol=Protocol.TCP),
+            PortSpec(internal_port=22, external_port=2222, protocol=Protocol.TCP),
         ),
         ("invalid", False, None),
         ("100000", False, None),


### PR DESCRIPTION
The `port forwarding create` command would exit with an error if you attempted to create a forwarding configuration that already exists. This made it difficult to identify actual failures.

This commit updates the `port forwarding create` command so that it is not an error if the requested forwarding already exists.

The old behavior was:

    $ openstack esi port forwarding create 192.168.11.31 128.31.20.118 -p 8888
    +--------------------------------------+---------------+---------------+----------+---------------+---------------+
    | ID                                   | Internal Port | External Port | Protocol | Internal IP   | External IP   |
    +--------------------------------------+---------------+---------------+----------+---------------+---------------+
    | 43c96be3-861d-4818-a32a-079a93b6f9c4 |          8888 |          8888 | tcp      | 192.168.11.31 | 128.31.20.118 |
    +--------------------------------------+---------------+---------------+----------+---------------+---------------+
    $ openstack esi port forwarding create esi-MOC-R4PAC24U35-S1B-provisioning 128.31.20.118 -p 8888 -p 8889
    BadRequestException: 400: Client Error for url:
    https://esi.massopen.cloud:13696/v2.0/floatingips/be4b2718-ec5f-4722-80b5-485c421e4a72/port_forwardings,
    Bad port_forwarding request: A duplicate port forwarding entry with
    same attributes already exists, conflicting values are
    {'floatingip_id': 'be4b2718-ec5f-4722-80b5-485c421e4a72',
    'external_port': 8888, 'protocol': 'tcp'}.

The new behavior looks like this:

    $ openstack esi port forwarding create 192.168.11.31 128.31.20.118 -p 8888
    +--------------------------------------+---------------+---------------+----------+---------------+---------------+
    | ID                                   | Internal Port | External Port | Protocol | Internal IP   | External IP   |
    +--------------------------------------+---------------+---------------+----------+---------------+---------------+
    | 43c96be3-861d-4818-a32a-079a93b6f9c4 |          8888 |          8888 | tcp      | 192.168.11.31 | 128.31.20.118 |
    +--------------------------------------+---------------+---------------+----------+---------------+---------------+
    $ openstack esi port forwarding create esi-MOC-R4PAC24U35-S1B-provisioning 128.31.20.118 -p 8888 -p 8889
    +--------------------------------------+---------------+---------------+----------+---------------+---------------+
    | ID                                   | Internal Port | External Port | Protocol | Internal IP   | External IP   |
    +--------------------------------------+---------------+---------------+----------+---------------+---------------+
    | exists                               |          8888 |          8888 | tcp      | 192.168.11.31 | 128.31.20.118 |
    | d7d56201-232a-41fe-8ae6-1f6fb88a37d3 |          8889 |          8889 | tcp      | 192.168.11.31 | 128.31.20.118 |
    +--------------------------------------+---------------+---------------+----------+---------------+---------------+