### PR TITLE
Make the "port forwarding delete" command idempotent

### DIFF
--- a/esiclient/v1/port_forwarding.py
+++ b/esiclient/v1/port_forwarding.py
@@ -416,7 +416,7 @@ class Delete(command.Lister, NetworkOpsMixin):
                     forwards.append((fip, fwd))
                     break
             else:
-                raise KeyError(f"could not find port forwarding matching {port}")
+                LOG.warning(f"port forwarding matching {port} does not exist")
 
         for fip, fwd in forwards:
             self.app.client_manager.sdk_connection.network.delete_floating_ip_port_forwarding(


### PR DESCRIPTION
Previously, attempting to delete a port forwarding that does not exist
would fail with:

    $ uv run openstack  esi port forwarding delete 172.17.1.106 128.31.20.118 -p 80
    'could not find port forwarding matching 80:80/tcp'
    $ echo $?
    1

With this change, we log a warning but do not consider it an error:

    $ uv run openstack  esi port forwarding delete 172.17.1.106 128.31.20.118 -p 80
    port forwarding matching 80:80/tcp does not exist
    $ echo $?
    0
